### PR TITLE
Updated gen_wts_yoloV5.py - cfg file fails to write due to encoding issues

### DIFF
--- a/utils/gen_wts_yoloV5.py
+++ b/utils/gen_wts_yoloV5.py
@@ -124,7 +124,7 @@ with open(wts_file, "w") as f:
     f.write(wts_write)
 
 with open(cfg_file, "w") as c:
-    with open(yaml_file, "r") as f:
+    with open(yaml_file, "r", encoding="utf-8") as f:
         nc = 0
         depth_multiple = 0
         width_multiple = 0


### PR DESCRIPTION
I ran into an issue with gen_wts_yoloV5.py where ascii-encoding error occurred when attempting to generate cfg file 
in the following step for YOLO v5.

4. Generate cfg and wts files (example for YOLOv5n)
```shell
python3 gen_wts_yoloV5.py -w yolov5n.pt
```

I got the following error: 

```
/root/yolov5# python3 gen_wts_yoloV5.py -w yolov5n.pt
YOLOv5 \U0001f680 v6.1-21-ge6e36aa torch 1.10.1+cu113 CPU

Traceback (most recent call last):
  File "gen_wts_yoloV5.py", line 133, in <module>
    f = yaml.load(f,Loader=yaml.FullLoader)
  File "/usr/local/lib/python3.6/dist-packages/yaml/__init__.py", line 79, in load
    loader = Loader(stream)
  File "/usr/local/lib/python3.6/dist-packages/yaml/loader.py", line 24, in __init__
    Reader.__init__(self, stream)
  File "/usr/local/lib/python3.6/dist-packages/yaml/reader.py", line 85, in __init__
    self.determine_encoding()
  File "/usr/local/lib/python3.6/dist-packages/yaml/reader.py", line 124, in determine_encoding
    self.update_raw()
  File "/usr/local/lib/python3.6/dist-packages/yaml/reader.py", line 178, in update_raw
    data = self.stream.read(size)
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xf0 in position 9: ordinal not in range(128)
```

If this is reproducible, I recommend making the following changes. If in the case where utf-8 encoding is not necessary on some environments, I will make the necessary changes to read with ascii encoding first before trying utf-8