### PR TITLE
Add yolov4 tiny

### DIFF
--- a/docs/YOLOv4-tiny.md
+++ b/docs/YOLOv4-tiny.md
@@ -1,0 +1,160 @@
+# YOLOv4-large usage
+
+**NOTE**: Follow this guide for yolov4-tiny from [PyTorch_YOLOv4](https://github.com/WongKinYiu/PyTorch_YOLOv4)
+
+- [Convert model](#convert-model)
+- [Compile the lib](#compile-the-lib)
+- [Edit the config_infer_primary file](#edit-the-config_infer_primary-file)
+- [Edit the deepstream_app_config file](#edit-the-deepstream_app_config-file)
+- [Testing the model](#testing-the-model)
+- [Implementation details about [route] layers in yolov4-tiny](#implementation-details-about-route-layers-in-yolov4-tiny)
+
+
+##
+
+### Convert model
+
+#### 1. Download the PyTorch_YOLOv4 repo and install the requirements
+
+```
+git clone https://github.com/WongKinYiu/PyTorch_YOLOv4
+cd PyTorch_YOLOv4
+pip3 install -r requirements.txt
+```
+
+**NOTE**: It is recommended to use Python virtualenv.
+
+
+#### 2. Copy conversor
+
+Copy the `gen_wts_yoloV4-tiny.py` file from `DeepStream-Yolo/utils` directory to the `PyTorch_YOLOv4` folder.
+
+#### 3. Download the model
+
+Fetch some `pt` weights for PyTorch_YOLOv4. There are none in the official repo but I found some [here]
+(https://github.com/tjuskyzhang/Scaled-YOLOv4-TensorRT/tree/master/yolov4-tiny-tensorrt). Nonetheless, note this process has been tested with both these weights and a model trained from scratch on the official PyTorch_YOLOv4 repo.
+
+Because PyTorch_YOLOv4's `.pt` format does not carry the model architecture, we need an additional `.cfg` file. This file is probably available in the PyTorch_YOLOv4/cfg repo.
+
+**NOTE**: You can use your custom model, but it is important to keep the YOLO model reference (`yolov4_`) in you `cfg` and `weights`/`wts` filenames to generate the engine correctly.
+**NOTE**: Commonly available YOLOv4-tiny cfg files have a typo making the second Yolo layer use anchors 1,2,3 rather than 0,1,2. Change it if you wish.
+
+#### 4. Convert model
+
+Generate the `cfg` and `wts` files from the `.pt` file. Here's how to run the script:
+
+```
+# Parameters explained
+python3 gen_wts_yoloV4-tiny.py -w weights.pt     # REQUIRED: input weights
+                               -s width [height] # OPTIONAL: image size, you can specify just the width for square imgs
+                               -n 80             # OPTIONAL: number of classes
+                               -c config.cfg     # OPTIONAL: path to input cfg file
+
+# Valid examples
+python3 gen_wts_yoloV4-tiny.py -w yolov4-tiny.pt
+python3 gen_wts_yoloV4-tiny.py -w yolov4-tiny.pt -s 480
+python3 gen_wts_yoloV4-tiny.py -w yolov4-tiny.pt -s 480 480 -n 80 -c custom-yolov4-tiny.cfg
+```
+
+The only required argument is the input weight files, as the rest can be automatically fetched:
+
+- Image size: can be inferred from the model training history packed in the `.pt`.
+- Number of classes: can be inferred from the number of weights of some layers in the `.pt`.
+- Input `cfg` file: if not passed, a file with the same name as the weights minus extensions will be fetched from `cfg/`
+
+The generated `cfg` and `wts` carry the `nvds` prefix to avoid confusion between input and output cfg files.
+
+**NOTE**: If your model fails to build an engine, try passing all arguments by hand.
+
+#### 5. Copy generated files
+
+Copy the generated `cfg` and `wts` files to the `DeepStream-Yolo` folder.
+
+##
+
+### Compile the lib
+
+Open the `DeepStream-Yolo` folder and compile the lib
+
+* DeepStream 6.1 on x86 platform
+
+  ```
+  CUDA_VER=11.6 make -C nvdsinfer_custom_impl_Yolo
+  ```
+
+* DeepStream 6.0.1 / 6.0 on x86 platform
+
+  ```
+  CUDA_VER=11.4 make -C nvdsinfer_custom_impl_Yolo
+  ```
+
+* DeepStream 6.1 on Jetson platform
+
+  ```
+  CUDA_VER=11.4 make -C nvdsinfer_custom_impl_Yolo
+  ```
+
+* DeepStream 6.0.1 / 6.0 on Jetson platform
+
+  ```
+  CUDA_VER=10.2 make -C nvdsinfer_custom_impl_Yolo
+  ```
+
+##
+
+### Edit the config_infer_primary file
+
+Edit the `config_infer_primary.txt` file according to your model:
+
+```
+[property]
+...
+custom-network-config=nvds-yolov4-tiny.cfg
+model-file=nvds-yolov4-tiny.wts
+...
+```
+
+##
+
+### Edit the deepstream_app_config file
+
+Make sure this file points to the one modified above.
+
+```
+...
+[primary-gie]
+...
+config-file=config_infer_primary.txt
+```
+
+##
+
+### Testing the model
+
+```
+deepstream-app -c deepstream_app_config.txt
+```
+
+
+## Implementation details about [route] layers in yolov4-tiny
+*This section is not needed to run Deepstream with YOLOv4-tiny*
+
+YOLOv4 tiny has two widely used implementations: one in Darknet and other in Pytorch. These are similar but have a different special `route` layer, which accomplish the same goal but are implemented differently. This layer is called `[route_lhalf]`, and takes *half* the feature maps from the preceding layer and passes it to the next one. In the cfg files, they are implemented as:
+
+**Torch**: official torch implementation [yolov4-tiny.cfg](https://github.com/WongKinYiu/PyTorch_YOLOv4/blob/master/cfg/yolov4-tiny.cfg)
+```
+[route_lhalf]
+layer=-1      # Take half of the layer -1
+```
+
+**Darknet**: standard `[route]` modified [yolov4-tiny.cfg](https://github.com/AlexeyAB/darknet/blob/master/cfg/yolov4-tiny.cfg)
+```
+[route]
+layer=-1    # Take the layer -1
+groups=2    # Divide its channels in 2 groups
+group_id=1  # Pass the 2nd to the next layer (0-indexed)
+```
+
+These implement the same concept, only Torch's implementation takes the 'left' half of feature maps, while Darknet's takes the 'right' one. This makes Darknet and Torch weights incompatible ([source1](https://github.com/tjuskyzhang/Scaled-YOLOv4-TensorRT/issues/5#issuecomment-677975656), [source2](https://github.com/WongKinYiu/ScaledYOLOv4/issues/165)).
+
+The script used in this tutorial uses `[route_lhalf]` layers, which come by default in PyTorch_YOLOv4 `cfg/` architectures, and are implemented in this repo at `nvdsinfer_custom_impl_Yolo/layers/route_lhalf_layer.cpp`. Alternatively, one might use a `cfg` with standard `[route]` layers implemented at `nvdsinfer_custom_impl_Yolo/layers/route_layer.cpp`, setting `group_id=0`.

--- a/nvdsinfer_custom_impl_Yolo/layers/route_lhalf_layer.cpp
+++ b/nvdsinfer_custom_impl_Yolo/layers/route_lhalf_layer.cpp
@@ -7,7 +7,7 @@
 
 nvinfer1::ITensor* route_lhalfLayer(
     int layerIdx,
-    std::string& layers,    // Just a string container for display
+    std::string& layers,
     std::map<std::string, std::string>& block,
     std::vector<nvinfer1::ITensor*> tensorOutputs,
     nvinfer1::INetworkDefinition* network)
@@ -18,67 +18,21 @@ nvinfer1::ITensor* route_lhalfLayer(
     assert(block.find("layers") != block.end());
 
     std::string strLayers = block.at("layers");
-    std::vector<int> idxLayers;
-    size_t lastPos = 0, pos = 0;
-    while ((pos = strLayers.find(',', lastPos)) != std::string::npos)
-    {
-        int vL = std::stoi(trim(strLayers.substr(lastPos, pos - lastPos)));
-        idxLayers.push_back(vL);
-        lastPos = pos + 1;
-    }
-    if (lastPos < strLayers.length())
-    {
-        std::string lastV = trim(strLayers.substr(lastPos));
-        if (!lastV.empty())
-            idxLayers.push_back(std::stoi(lastV));
-    }
-    assert (!idxLayers.empty());
-    std::vector<nvinfer1::ITensor*> concatInputs;
-    for (uint i = 0; i < idxLayers.size(); ++i)
-    {
-        if (idxLayers[i] < 0)
-            idxLayers[i] = tensorOutputs.size() + idxLayers[i];
-        assert (idxLayers[i] >= 0 && idxLayers[i] < (int)tensorOutputs.size());
-        concatInputs.push_back(tensorOutputs[idxLayers[i]]);
-        if (i < idxLayers.size() - 1)
-            layers += std::to_string(idxLayers[i]) + ", ";
-    }
-    layers += std::to_string(idxLayers[idxLayers.size() - 1]);
+    assert ( strLayers.find(',') == std::string::npos ) ;
+    int idxLayer = std::stoi(trim(strLayers));
 
-    assert (concatInputs.size() == 1);
-    if (concatInputs.size() == 1)
-        output = concatInputs[0];
+    if (idxLayer < 0)
+            idxLayer = tensorOutputs.size() + idxLayer;
+    assert (idxLayer >= 0 && idxLayer < (int)tensorOutputs.size());
+    output = tensorOutputs[idxLayer];
+    layers += std::to_string(idxLayer);
 
-    // route_lhalf should always have a single input
-    // So this block below can be supressed
-    /*
-    else {
-        int axis = 0;
-        if (block.find("axis") != block.end())
-            axis = std::stoi(block.at("axis"));
-        if (axis < 0)
-            axis = concatInputs[0]->getDimensions().nbDims + axis;
-
-        nvinfer1::IConcatenationLayer* concat = network->addConcatenation(concatInputs.data(), concatInputs.size());
-        assert(concat != nullptr);
-        std::string concatLayerName = "route_" + std::to_string(layerIdx);
-        concat->setName(concatLayerName.c_str());
-        concat->setAxis(axis);
-        output = concat->getOutput(0);
-    }
-    */
-
-    // Implementation based on [route] as [route_lhalf] is jsut a particular case
     nvinfer1::Dims prevTensorDims = output->getDimensions();
-    int groups = 2;  // stoi(block.at("groups"));
-    int group_id = 0;  // stoi(block.at("group_id"));
-    int startSlice = (prevTensorDims.d[0] / groups) * group_id;
-    int channelSlice = (prevTensorDims.d[0] / groups);
-
     nvinfer1::ISliceLayer* slice = network->addSlice(
-        *output, nvinfer1::Dims{3, {startSlice, 0, 0}},
-        nvinfer1::Dims{3, {channelSlice, prevTensorDims.d[1], prevTensorDims.d[2]}}, nvinfer1::Dims{3, {1, 1, 1}});
-
+        *output,
+        nvinfer1::Dims{3, {0, 0, 0}},
+        nvinfer1::Dims{3, {prevTensorDims.d[0] / 2, prevTensorDims.d[1], prevTensorDims.d[2]}},
+        nvinfer1::Dims{3, {1, 1, 1}});
     assert(slice != nullptr);
     std::string sliceLayerName = "slice_" + std::to_string(layerIdx);
     slice->setName(sliceLayerName.c_str());

--- a/nvdsinfer_custom_impl_Yolo/layers/route_lhalf_layer.cpp
+++ b/nvdsinfer_custom_impl_Yolo/layers/route_lhalf_layer.cpp
@@ -1,0 +1,88 @@
+/*
+ * Created by Pablo Santana :)
+ * https://www.github.com/pabsan-0
+ */
+
+#include "route_lhalf_layer.h"
+
+nvinfer1::ITensor* route_lhalfLayer(
+    int layerIdx,
+    std::string& layers,    // Just a string container for display
+    std::map<std::string, std::string>& block,
+    std::vector<nvinfer1::ITensor*> tensorOutputs,
+    nvinfer1::INetworkDefinition* network)
+{
+    nvinfer1::ITensor* output;
+
+    assert(block.at("type") == "route_lhalf");
+    assert(block.find("layers") != block.end());
+
+    std::string strLayers = block.at("layers");
+    std::vector<int> idxLayers;
+    size_t lastPos = 0, pos = 0;
+    while ((pos = strLayers.find(',', lastPos)) != std::string::npos)
+    {
+        int vL = std::stoi(trim(strLayers.substr(lastPos, pos - lastPos)));
+        idxLayers.push_back(vL);
+        lastPos = pos + 1;
+    }
+    if (lastPos < strLayers.length())
+    {
+        std::string lastV = trim(strLayers.substr(lastPos));
+        if (!lastV.empty())
+            idxLayers.push_back(std::stoi(lastV));
+    }
+    assert (!idxLayers.empty());
+    std::vector<nvinfer1::ITensor*> concatInputs;
+    for (uint i = 0; i < idxLayers.size(); ++i)
+    {
+        if (idxLayers[i] < 0)
+            idxLayers[i] = tensorOutputs.size() + idxLayers[i];
+        assert (idxLayers[i] >= 0 && idxLayers[i] < (int)tensorOutputs.size());
+        concatInputs.push_back(tensorOutputs[idxLayers[i]]);
+        if (i < idxLayers.size() - 1)
+            layers += std::to_string(idxLayers[i]) + ", ";
+    }
+    layers += std::to_string(idxLayers[idxLayers.size() - 1]);
+
+    assert (concatInputs.size() == 1);
+    if (concatInputs.size() == 1)
+        output = concatInputs[0];
+
+    // route_lhalf should always have a single input
+    // So this block below can be supressed
+    /*
+    else {
+        int axis = 0;
+        if (block.find("axis") != block.end())
+            axis = std::stoi(block.at("axis"));
+        if (axis < 0)
+            axis = concatInputs[0]->getDimensions().nbDims + axis;
+
+        nvinfer1::IConcatenationLayer* concat = network->addConcatenation(concatInputs.data(), concatInputs.size());
+        assert(concat != nullptr);
+        std::string concatLayerName = "route_" + std::to_string(layerIdx);
+        concat->setName(concatLayerName.c_str());
+        concat->setAxis(axis);
+        output = concat->getOutput(0);
+    }
+    */
+
+    // Implementation based on [route] as [route_lhalf] is jsut a particular case
+    nvinfer1::Dims prevTensorDims = output->getDimensions();
+    int groups = 2;  // stoi(block.at("groups"));
+    int group_id = 0;  // stoi(block.at("group_id"));
+    int startSlice = (prevTensorDims.d[0] / groups) * group_id;
+    int channelSlice = (prevTensorDims.d[0] / groups);
+
+    nvinfer1::ISliceLayer* slice = network->addSlice(
+        *output, nvinfer1::Dims{3, {startSlice, 0, 0}},
+        nvinfer1::Dims{3, {channelSlice, prevTensorDims.d[1], prevTensorDims.d[2]}}, nvinfer1::Dims{3, {1, 1, 1}});
+
+    assert(slice != nullptr);
+    std::string sliceLayerName = "slice_" + std::to_string(layerIdx);
+    slice->setName(sliceLayerName.c_str());
+    output = slice->getOutput(0);
+
+    return output;
+}

--- a/nvdsinfer_custom_impl_Yolo/layers/route_lhalf_layer.h
+++ b/nvdsinfer_custom_impl_Yolo/layers/route_lhalf_layer.h
@@ -1,0 +1,20 @@
+/*
+ * Created by Pablo Santana :)
+ * https://www.github.com/pabsan-0
+ */
+
+
+#ifndef __ROUTE_LHALF_LAYER_H__
+#define __ROUTE_LHALF_LAYER_H__
+
+#include "NvInfer.h"
+#include "../utils.h"
+
+nvinfer1::ITensor* route_lhalfLayer(
+    int layerIdx,
+    std::string& layers,
+    std::map<std::string, std::string>& block,
+    std::vector<nvinfer1::ITensor*> tensorOutputs,
+    nvinfer1::INetworkDefinition* network);
+
+#endif

--- a/nvdsinfer_custom_impl_Yolo/yolo.h
+++ b/nvdsinfer_custom_impl_Yolo/yolo.h
@@ -32,6 +32,7 @@
 #include "layers/channels_layer.h"
 #include "layers/shortcut_layer.h"
 #include "layers/route_layer.h"
+#include "layers/route_lhalf_layer.h"
 #include "layers/upsample_layer.h"
 #include "layers/pooling_layer.h"
 #include "layers/reorg_layer.h"

--- a/utils/gen_wts_yoloV4-tiny.py
+++ b/utils/gen_wts_yoloV4-tiny.py
@@ -1,0 +1,197 @@
+
+import struct
+import sys
+from models import *
+from models.models import *
+from utils.utils import *
+import argparse
+
+
+class CfgFixer:
+
+    def __init__(self, inputcfg, classes, width, height=None):
+
+        # Define dump for the input file + class retrieval point
+        # file_out = inputcfg.split('.')[0] + '_adjusted.cfg'
+        file_out = inputcfg.split('/')[1]
+        self.file_out = file_out
+
+        # Receive input width and stuff
+        width = int(width)
+        height = int(height) if height else width
+        assert height % 32 == 0
+        assert width % 32 == 0
+
+        # Load the input file to a list
+        file_content = []
+        with open(inputcfg, 'r') as file_object:
+            for line in file_object:
+                file_content.append(line)
+
+        # Compute the number of filters and where to place them
+        filters = int((int(classes)+5)*3)
+        lines_filter_before_yolo = self.exact_filter_line(file_content)
+
+        # Actually modify the file with AlexeyAB described changes
+        with open(file_out, 'w') as file_object:
+            for idx,line in enumerate(file_content):
+
+                if any(['batch=' in line and 'batch_' not in line and '_batch' not in line,
+                       'subdivisions=' in line,
+                       'max_batche=s' in line,
+                       'steps=' in line and 'policy' not in line
+                        ]):
+                    # We don't do that here
+                    pass
+
+                elif 'width=' in line:
+                    file_object.write(f'width={width}'+'\n')
+
+                elif 'height=' in line:
+                    file_object.write(f'height={height}'+'\n')
+
+                elif 'classes=' in line:
+                    file_object.write(f'classes={classes}'+'\n')
+
+                elif idx in lines_filter_before_yolo:
+                    file_object.write(f'filters={filters}'+'\n')
+
+                else:
+                    file_object.write(line)
+
+
+
+    @staticmethod
+    def exact_filter_line(file_content):
+        """ Get the exact line of the last filter line before each yolo layer """
+
+        # Scan the file for the [yolo] and filter= lines
+        yolo_lines = [i for i,line in enumerate(file_content) if '[yolo]' in line]
+        filter_lines = [i for i,line in enumerate(file_content) if 'filters' in line]
+
+        # Get only the filter lines prior to yolo layers
+        exact_filter_list = []
+        for i in yolo_lines:
+            it = filter(lambda number: number < i, filter_lines)
+            filtered_numbers = list(it)
+            exact_filter_list.append(filtered_numbers[-1])
+
+        return exact_filter_list
+
+
+def route_fix(file_out):
+    route_fix_context = False
+
+    # Load file content into memory
+    with open(file_out, 'r') as file_object:
+        file_content = []
+        for line in file_object:
+            file_content.append(line)
+
+    # Truncate and rewrite file, translating [route_lhalf] -> [route]
+    with open(file_out, 'w') as file_object:
+        for idx,line in enumerate(file_content):
+            if '[route_lhalf]' in line:
+                route_fix_context = True
+                file_object.write('[route]' + '\n')
+
+            elif route_fix_context:
+                if '[' in line:
+                    route_fix_context = False
+                    file_object.write(line)
+
+                elif 'layers' in line:
+                    file_object.write(line)
+                    file_object.write('groups=2'+'\n')
+                    file_object.write('group_id=1'+'\n'*2)
+
+            else:
+                file_object.write(line)
+
+
+def classes_from_wts(weights):
+    tmp_model = torch.load(weights, map_location='cpu')
+    filters = [i for i in tmp_model['model'].values()][-1].shape
+    classes = filters[0] / 3 - 5
+    return int(classes)
+
+def cfg_from_wts(weights):
+    return 'cfg/' + weights.split('_')[0] + '.cfg'
+
+def imsize_from_wts(weights):
+    tmp_model = torch.load(weights, map_location='cpu')
+    row = tmp_model['training_results'].split('\n')[0]
+    imsize = row.split()[7]
+    return imsize
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='''Create YOLOv4-tiny wts+cfg''')
+    parser.add_argument('--weights',  '-w',  type=str, required=True, help='network size')
+    parser.add_argument('--nclasses', '-n',  type=int, help='Detect how many classes')
+    parser.add_argument('--imsize',   '-s',  type=int, help='network size')
+    parser.add_argument('--inputcfg', '-c',  type=str, help='Path to default .cfg')
+
+    # Args to dict and purge Nones to use .get(val, default) later
+    args = vars(parser.parse_args())
+    args = {k: v for k, v in args.items() if v is not None}
+
+    weights  = args.get('weights')
+    imsize   = args.get('imsize',   imsize_from_wts(weights))
+    inputcfg = args.get('inputcfg', cfg_from_wts(weights))
+    classes  = args.get('nclasses', classes_from_wts(weights))
+
+    print(weights, imsize, inputcfg, classes)
+
+
+    # Fix cdf with AlexeyAB configuration
+    newcfg = CfgFixer(inputcfg, classes, imsize).file_out
+    model = Darknet(newcfg, (imsize, imsize))
+    route_fix(newcfg)
+
+    dev = 'cpu'
+    if weights.endswith('.pt'):  # pytorch format
+        model.load_state_dict(torch.load(weights, map_location=dev)['model'])
+    else:
+        raise Exception('Unknown weight type / file not found')
+        # load_darknet_weights(model, weights)
+
+    f = open('yolov4-tiny.wts', 'w')
+    f.write('{}\n'.format(len(model.state_dict().keys())))
+    wt_so_far =0
+    k_old = '0.0'
+
+    index = lambda k, i=1: k.split('.')[i]
+    iindex = lambda k, i=1: int(k.split('.')[i])
+    diff = lambda x, y: int(index(x)) - int(index(y))
+
+    for k, v in model.state_dict().items():
+
+        # Print summary of PREVIOUS layer
+        if diff(k, k_old) >= 1:
+            print(index(k_old), wt_so_far)
+
+        # Fill in intermediate layer indices
+        if diff(k, k_old) >= 2:
+            for i in range(iindex(k_old)+1, iindex(k)):
+                print(i, '-')
+
+        if 'num_batches_tracked' not in k:
+            # print('\t', v.shape)
+            vr = v.reshape(-1).numpy()
+            f.write('{} {}'.format(k, len(vr)))
+            for vv in vr:
+                f.write(' ')
+                f.write(struct.pack('>f',float(vv)).hex())
+                wt_so_far +=1
+            f.write('\n')
+
+        # print(index(k), k, wt_so_far)
+        k_old = k
+
+    # Last layer manually printed out
+    print(index(k_old), wt_so_far)
+    print(iindex(k_old) +1 , '-')
+
+
+

--- a/utils/gen_wts_yoloV4-tiny.py
+++ b/utils/gen_wts_yoloV4-tiny.py
@@ -157,7 +157,7 @@ if __name__ == '__main__':
         # load_darknet_weights(model, weights)
 
     f = open('yolov4-tiny.wts', 'w')
-    f.write('{}\n'.format(len(model.state_dict().keys())))
+    f.write('{}\n'.format(len([k for k in model.state_dict().keys() if 'batch' not in k])))
     wt_so_far =0
     k_old = '0.0'
 
@@ -170,7 +170,6 @@ if __name__ == '__main__':
         # Print summary of PREVIOUS layer
         if diff(k, k_old) >= 1:
             print(index(k_old), wt_so_far)
-
         # Fill in intermediate layer indices
         if diff(k, k_old) >= 2:
             for i in range(iindex(k_old)+1, iindex(k)):
@@ -186,12 +185,11 @@ if __name__ == '__main__':
                 wt_so_far +=1
             f.write('\n')
 
-        # print(index(k), k, wt_so_far)
         k_old = k
 
     # Last layer manually printed out
     print(index(k_old), wt_so_far)
-    print(iindex(k_old) +1 , '-')
+    print(iindex(k_old) + 1 , '-')
 
 
 


### PR DESCRIPTION
Hello! This PR adds support for torch based YOLOv4-tiny from [PyTorch_YOLOv4](https://github.com/WongKinYiu/PyTorch_YOLOv4) to convert from `pt+cfg` to `wts+cfg`.

- [x] Added `[route_lhalf]` layer to `nvdsinfer_custom_impl_Yolo`
- [x] Added converter script from `pt+cfg` -> `wts+cfg`
- [x] Added tutorial + some notes on `[route_lhalf]` layer

Tested on Deepstream 6.1.