### PR TITLE
Add symmetric-padding option in yolov5 infer config

### DIFF
--- a/config_infer_primary_yoloV5.txt
+++ b/config_infer_primary_yoloV5.txt
@@ -19,6 +19,7 @@ maintain-aspect-ratio=1
 parse-bbox-func-name=NvDsInferParseYolo
 custom-lib-path=nvdsinfer_custom_impl_Yolo/libnvdsinfer_custom_impl_Yolo.so
 engine-create-func-name=NvDsInferYoloCudaEngineGet
+symmetric-padding=1
 
 [class-attrs-all]
 nms-iou-threshold=0.45


### PR DESCRIPTION
Hello, it's not a huge performance improvement only for yolov5, but I'm doing a pr because I want to fit the way I trained yolov5
다

Basically, ultralitics yolov5 uses up-down or left-right padding letterbox instead of right-bottom for data input processing
From this point of view, what Deepstream can do is first, there are main-aspect-ratio and symmetric-padding options
You can check the contents of the symmetric-padding option at the link below

https://docs.nvidia.com/metropolis/deepstream/6.0.1/dev-guide/text/DS_plugin_gst-nvinfer.html
![image](https://user-images.githubusercontent.com/99321359/198925668-db0aa9b6-58fc-4c7a-b36e-9b388a5f7015.png)

In fact, if you look at the code related to nvinfer, you can see that the default setup (padding=0) is Right-bottom

location
/opt/nvidia/deepstream/deepstream/sources/gst-plugins/gst-nvinfer/gstnvinfer.cpp (deepstream 6.0.1)
line 1130
```cpp
/* Pad the scaled image with black color. */
    if (!nvinfer->symmetric_padding) {
      /* Right-Bottom Padding. */
      cudaReturn =
          cudaMemset2DAsync ((uint8_t *) destCudaPtr + pixel_size * dest_width,
          dest_frame->planeParams.pitch[0], 0,
          pixel_size * (dest_frame->width - dest_width), dest_frame->height,
          nvinfer->convertStream);
      if (cudaReturn != cudaSuccess) {
        GST_ERROR_OBJECT (nvinfer,
            "cudaMemset2DAsync failed with error %s while converting buffer",
            cudaGetErrorName (cudaReturn));
        return GST_FLOW_ERROR;
      }
      cudaReturn =
          cudaMemset2DAsync ((uint8_t *) destCudaPtr +
          dest_frame->planeParams.pitch[0] * dest_height,
          dest_frame->planeParams.pitch[0], 0, pixel_size * dest_width,
          dest_frame->height - dest_height, nvinfer->convertStream);
      if (cudaReturn != cudaSuccess) {
        GST_ERROR_OBJECT (nvinfer,
            "cudaMemset2DAsync failed with error %s while converting buffer",
            cudaGetErrorName (cudaReturn));
        return GST_FLOW_ERROR;
      }
    } else {
      /* Symmetric Padding. */
      offset_left = (dest_frame->width - dest_width) / 2;
      offset_right = dest_frame->width - dest_width - offset_left;

      cudaReturn =
          cudaMemset2DAsync ((uint8_t *) destCudaPtr,
          dest_frame->planeParams.pitch[0], 0,
          pixel_size * offset_left, dest_frame->height, nvinfer->convertStream);
      if (cudaReturn != cudaSuccess) {
        GST_ERROR_OBJECT (nvinfer,
            "cudaMemset2DAsync failed with error %s while converting buffer",
            cudaGetErrorName (cudaReturn));
        return GST_FLOW_ERROR;
      }

      cudaReturn =
          cudaMemset2DAsync ((uint8_t *) destCudaPtr + pixel_size *
          (dest_width + offset_left),
          dest_frame->planeParams.pitch[0], 0,
          pixel_size * offset_right, dest_frame->height,
          nvinfer->convertStream);
      if (cudaReturn != cudaSuccess) {
        GST_ERROR_OBJECT (nvinfer,
            "cudaMemset2DAsync failed with error %s while converting buffer",
            cudaGetErrorName (cudaReturn));
        return GST_FLOW_ERROR;
      }

      offset_top = (dest_frame->height - dest_height) / 2;
      offset_bottom = dest_frame->height - dest_height - offset_top;

      cudaReturn =
          cudaMemset2DAsync ((uint8_t *) destCudaPtr,
          dest_frame->planeParams.pitch[0], 0, pixel_size * dest_width,
          offset_top, nvinfer->convertStream);
      if (cudaReturn != cudaSuccess) {
        GST_ERROR_OBJECT (nvinfer,
            "cudaMemset2DAsync failed with error %s while converting buffer",
            cudaGetErrorName (cudaReturn));
        return GST_FLOW_ERROR;
      }

      cudaReturn =
          cudaMemset2DAsync ((uint8_t *) destCudaPtr +
          dest_frame->planeParams.pitch[0] * (dest_height + offset_top),
          dest_frame->planeParams.pitch[0], 0, pixel_size * dest_width,
          offset_bottom, nvinfer->convertStream);
      if (cudaReturn != cudaSuccess) {
        GST_ERROR_OBJECT (nvinfer,
            "cudaMemset2DAsync failed with error %s while converting buffer",
            cudaGetErrorName (cudaReturn));
        return GST_FLOW_ERROR;
      }
    }
```

The MAP below is limited to the dataset I use, but there is a slight improvement in performance when padding=1, so I would appreciate it if you could reconsider the above option for a better MAP

- symmetric-padding=1
  ![image](https://user-images.githubusercontent.com/99321359/198925510-d8e34318-42bb-4985-86d0-2844a6579e3f.png)

- symmetric-padding=0
  ![image](https://user-images.githubusercontent.com/99321359/198925596-2e473a28-86f6-4cbe-8775-1af969886d00.png)
