### PR TITLE
fix: handle integer labels in creating labels.txt in export_yoloV8

### DIFF
--- a/utils/export_yoloV8.py
+++ b/utils/export_yoloV8.py
@@ -61,7 +61,10 @@ def main(args):
         print('\nCreating labels.txt file')
         f = open('labels.txt', 'w')
         for name in model.names.values():
-            f.write(name + '\n')
+            if isinstance(name, int):
+                f.write(str(name) + '\n')
+            else:
+                f.write(name + '\n')
         f.close()
 
     model = nn.Sequential(model, DeepStreamOutput())


### PR DESCRIPTION
The previous code in [utils/export_yoloV8.py](https://github.com/marcoslucianops/DeepStream-Yolo/blob/9bda315ee0834ca0fb2d7f6b5f34c0a69ddc24e0/utils/export_yoloV8.py#L64C13-L64C13) assumed label values are always strings, causing issues when the model has integer labels (like: 0, 1, 2, ...). This commit adds a check to handle both string and integer labels properly. If the label is an integer, it is converted to a string before writing to the 'labels.txt' file.

