### PR TITLE
Fix ONNX file name to avoid .pt.onnx

### DIFF
--- a/utils/export_yoloV8.py
+++ b/utils/export_yoloV8.py
@@ -94,7 +94,7 @@ def main(args):
     img_size = args.size * 2 if len(args.size) == 1 else args.size
 
     onnx_input_im = torch.zeros(args.batch, 3, *img_size).to(device)
-    onnx_output_file = f'{args.weights}.onnx'
+    onnx_output_file = args.weights.replace(".pt", "") + ".onnx"
 
     dynamic_axes = {
         'input': {


### PR DESCRIPTION
Currently, the script generates files with the name `best.pt.onnx` when exporting a YOLOv8 model to ONNX.
This can cause problems integrating with other systems.

I changed the filename generation to remove the `.pt` extension, ensuring the result is `best.onnx` instead of `best.pt.onnx`.

Example of command that causes the problem: