### PR TITLE
D-FINE Opset 17 Fix

### DIFF
--- a/docs/DFINE.md
+++ b/docs/DFINE.md
@@ -82,7 +82,7 @@ or
 --batch 4
 ```
 
-**NOTE**: If you are using the DeepStream 5.1, remove the `--dynamic` arg and use opset 12 or lower. The default opset is 16.
+**NOTE**: If you are using the DeepStream 5.1, remove the `--dynamic` arg and use opset 12 or lower. The default opset is 17.
 
 ```
 --opset 12

--- a/utils/export_dfine.py
+++ b/utils/export_dfine.py
@@ -95,7 +95,7 @@ def parse_args():
     parser.add_argument('-w', '--weights', required=True, help='Input weights (.pth) file path (required)')
     parser.add_argument('-c', '--config', required=True, help='Input YAML (.yml) file path (required)')
     parser.add_argument('-s', '--size', nargs='+', type=int, default=[640], help='Inference size [H,W] (default [640])')
-    parser.add_argument('--opset', type=int, default=16, help='ONNX opset version')
+    parser.add_argument('--opset', type=int, default=17, help='ONNX opset version')
     parser.add_argument('--simplify', action='store_true', help='ONNX simplify model')
     parser.add_argument('--dynamic', action='store_true', help='Dynamic batch-size')
     parser.add_argument('--batch', type=int, default=1, help='Static batch-size')


### PR DESCRIPTION
Hi @marcoslucianops ,

This Pull Request proposes changing the export script for the D-FINE model to use ONNX opset version 17 by default.

# The Problem
Currently, using the default opset version 16, converting the D-FINE model to a TensorRT engine with FP16 precision leads to a complete functional failure. I don't know if you alread tried.

# Observed symptoms

- The engine generated in FP32 works correctly and produces good detections.
- The engine generated in FP16 produces zero detections, even with a very low confidence threshold (e.g., 0.01). This behavior indicates a catastrophic numerical collapse (NaN/Infinity) during half-precision inference.

# Suspected Root Cause and Justification
The issue is directly related to how older ONNX versions decompose certain operations, especially LayerNormalization, which is ubiquitous in Transformer-based models like D-FINE.

- FP16 Instability: Older opset versions break LayerNormalization down into a series of basic operations (Reduce, Pow, etc.). The intermediate calculations, particularly the squaring operation (Pow), generate values that exceed the maximum representable value of the FP16 format (max 65,504), causing an overflow and corrupting the layer's output.

- The Opset 17 Solution: Opset 17 standardized the LayerNormalization operation. By exporting with this opset, a native INormalizationLayer node is generated in the ONNX graph. TensorRT recognizes this node and can apply its own internal, optimized routines, which are numerically stable and safe for FP16 execution.

Again, I can’t guarantee this is the full explanation, but switching to opset 17 immediately resolved the issue in my tests.

This solution is also mentioned in [issue #98 of the D-FINE repository](https://github.com/Peterande/D-FINE/issues/98), where the same failure is described and solved by exporting with opset 17.

# Benefit of This Change
By setting the default opset value to 17 in the export script, we ensure that:

- Users will generate a functional and reliable FP16 engine out-of-the-box.
- Performance on deployment platforms (NVIDIA Jetson, servers with Tensor Cores) will be optimal, which is the primary goal of using FP16 precision.

Thank you for considering this change.