### PR TITLE
fix weights_only problem with pytorch

### DIFF
--- a/utils/export_yolo11.py
+++ b/utils/export_yolo11.py
@@ -35,7 +35,7 @@ class DeepStreamOutput(nn.Module):
 
 
 def yolo11_export(weights, device, inplace=True, fuse=True):
-    ckpt = torch.load(weights, map_location='cpu')
+    ckpt = torch.load(weights, map_location='cpu', weights_only=False)
     ckpt = (ckpt.get('ema') or ckpt['model']).to(device).float()
     if not hasattr(ckpt, 'stride'):
         ckpt.stride = torch.tensor([32.])


### PR DESCRIPTION
The export utilities only work with `torch.load(..., weights_only=False)` 
See [here](https://github.com/MIC-DKFZ/nnUNet/issues/2681)