### PR TITLE
Torch 2.9.0 support

### DIFF
--- a/utils/export_codetr.py
+++ b/utils/export_codetr.py
@@ -111,7 +111,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_damoyolo.py
+++ b/utils/export_damoyolo.py
@@ -80,7 +80,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_dfine.py
+++ b/utils/export_dfine.py
@@ -76,7 +76,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_goldyolo.py
+++ b/utils/export_goldyolo.py
@@ -86,7 +86,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_rtdetr_pytorch.py
+++ b/utils/export_rtdetr_pytorch.py
@@ -74,7 +74,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_rtdetr_ultralytics.py
+++ b/utils/export_rtdetr_ultralytics.py
@@ -84,7 +84,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_rtmdet.py
+++ b/utils/export_rtmdet.py
@@ -112,7 +112,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_yolo11.py
+++ b/utils/export_yolo11.py
@@ -106,7 +106,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_yoloV10.py
+++ b/utils/export_yoloV10.py
@@ -121,7 +121,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_yoloV5.py
+++ b/utils/export_yoloV5.py
@@ -81,7 +81,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_yoloV5u.py
+++ b/utils/export_yoloV5u.py
@@ -106,7 +106,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_yoloV6.py
+++ b/utils/export_yoloV6.py
@@ -87,7 +87,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_yoloV7.py
+++ b/utils/export_yoloV7.py
@@ -87,7 +87,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_yoloV7_u6.py
+++ b/utils/export_yoloV7_u6.py
@@ -78,7 +78,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_yoloV8.py
+++ b/utils/export_yoloV8.py
@@ -106,7 +106,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_yoloV9.py
+++ b/utils/export_yoloV9.py
@@ -110,7 +110,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_yolonas.py
+++ b/utils/export_yolonas.py
@@ -62,7 +62,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_yolor.py
+++ b/utils/export_yolor.py
@@ -98,7 +98,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:

--- a/utils/export_yolox.py
+++ b/utils/export_yolox.py
@@ -75,7 +75,8 @@ def main(args):
     print('Exporting the model to ONNX')
     torch.onnx.export(
         model, onnx_input_im, onnx_output_file, verbose=False, opset_version=args.opset, do_constant_folding=True,
-        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None
+        input_names=['input'], output_names=['output'], dynamic_axes=dynamic_axes if args.dynamic else None,
+        dynamo=False
     )
 
     if args.simplify:


### PR DESCRIPTION
Hello @marcoslucianops,

This pull request proposes changing the export scripts to support torch version 2.9.0 by specifying Dynamo value as specified in the release note.

# The problem

Currently, the export is not working with version 2.9.0.

I initially had the issue with D-FINE but seeing this [issue](https://github.com/marcoslucianops/DeepStream-Yolo/issues/668), i made the changes for all.

# Solution

By setting the default value of dynamo to False, we ensure that it is compatible with newer versions.

Thanks for considering the change.