### PR TITLE
Fix INT8 calibrator offset indexing

### DIFF
--- a/nvdsinfer_custom_impl_Yolo/calibrator.cpp
+++ b/nvdsinfer_custom_impl_Yolo/calibrator.cpp
@@ -124,7 +124,7 @@ prepareImage(cv::Mat& img, int inputC, int inputH, int inputW, float scaleFactor
     cv::subtract(out, cv::Scalar(offsets[0] / 255), out);
   }
   else {
-    cv::subtract(out, cv::Scalar(offsets[0] / 255, offsets[1] / 255, offsets[3] / 255), out);
+    cv::subtract(out, cv::Scalar(offsets[0] / 255, offsets[1] / 255, offsets[2] / 255), out);
   }
 
   std::vector<cv::Mat> inputChannels(inputC);


### PR DESCRIPTION
  This fixes the INT8 calibrator preprocessing for 3-channel input.

  `calibrator.cpp` currently uses `offsets[3]` for the third channel:
  `cv::Scalar(offsets[0] / 255, offsets[1] / 255, offsets[3] / 255)`

  The sample configs define three offsets, so the third value should be `offsets[2]`.

  This change only affects the INT8 calibration path.